### PR TITLE
Fix build issues

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,6 +58,7 @@ module.exports = {
 
             config.plugins.push(
                 new WorkboxPlugin.InjectManifest({
+                    maximumFileSizeToCacheInBytes: 5000000, // 5mb
                     swSrc: path.resolve('src', 'sw', 'index.ts'),
                     swDest: path.resolve(serviceWorkerDest),
                     dontCacheBustURLsMatching: /^\/_next\/static\//,

--- a/src/pages/api/page/[id].ts
+++ b/src/pages/api/page/[id].ts
@@ -16,7 +16,7 @@ const schema = _schema as Schema;
 export default function handler(req: NextApiRequest, res: NextApiResponse): void {
     const { query: { id } } = req;
 
-    if (!(id in schema)) {
+    if (!(id as string in schema)) {
         res.status(404);
     }
 

--- a/src/pages/api/page/[id].ts
+++ b/src/pages/api/page/[id].ts
@@ -14,14 +14,15 @@ const pages = _pages as Pages;
 const schema = _schema as Schema;
 
 export default function handler(req: NextApiRequest, res: NextApiResponse): void {
-    const { query: { id } } = req;
+    const { query } = req;
+    const id = query.id as string;
 
-    if (!(id as string in schema)) {
+    if (!(id in schema)) {
         res.status(404);
     }
 
-    const title = schema[id as string];
-    const content = pages[id as string];
+    const title = schema[id];
+    const content = pages[id];
 
     res.status(200).json({
         id,


### PR DESCRIPTION
# This PR Fixes
* Issue 1: Warning: won't be precached due to large in size.
```
static/chunks/main.js is 4.38 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.

static/chunks/pages/[page].js is 3.96 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.

static/chunks/pages/_app.js is 3.88 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.

static/chunks/pages/index.js is 3.96 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.

static/chunks/pages/pages.js is 3.52 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.

static/chunks/pages/profile.js is 3.26 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.
```
* Issue 2: Type casting was missing.
```
$ next build
Failed to compile.

./src/pages/api/page/[id].ts:19:11
Type error: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.

  17 |     const { query: { id } } = req;
  18 | 
> 19 |     if (!(id in schema)) {
     |           ^
  20 |         res.status(404);
  21 |     }
  22 | 
error Command failed with exit code 1.
```