### PR TITLE
Fix document fetch not working properly in offline mode

### DIFF
--- a/src/sw/utils/getBuildManifest.ts
+++ b/src/sw/utils/getBuildManifest.ts
@@ -1,0 +1,14 @@
+declare const self: ServiceWorkerGlobalScope;
+
+const getBuildManifest = (): NextBuildManifest => {
+    const manifest = self.__BUILD_MANIFEST;
+
+    return Object.entries(manifest).reduce<NextBuildManifest>(
+        (manifest, [page, assets]) => ({
+            ...manifest,
+            [page]: assets.map(url => `/_next/${url}`)
+        }), {}
+    );
+};
+
+export default getBuildManifest;

--- a/src/sw/utils/getBuildManifestPages.ts
+++ b/src/sw/utils/getBuildManifestPages.ts
@@ -1,0 +1,9 @@
+import getBuildManifest from './getBuildManifest';
+
+const getBuildManifestPages = (): string[] => {
+    const { sortedPages, __rewrites, ...manifest } = getBuildManifest();
+
+    return Object.keys(manifest).filter(url => !url.includes('/_'));
+};
+
+export default getBuildManifestPages;

--- a/src/sw/utils/getRequestedPageFromURL.ts
+++ b/src/sw/utils/getRequestedPageFromURL.ts
@@ -1,0 +1,42 @@
+import getBuildManifestPages from './getBuildManifestPages';
+
+const getRequestedPageFromURL = (url: string): string | undefined => {
+    const { pathname } = new URL(url);
+    const manifest = getBuildManifestPages();
+
+    /*
+     * If URL is not dynamic.
+     */
+    if (manifest.indexOf(pathname) > -1) {
+        return pathname;
+    }
+
+    /*
+     * The URL might be dynamic,
+     * try to find page by going through
+     * manifest page paths.
+     */
+    const requestedPage = pathname.split('/');
+
+    return manifest.find(
+        page => {
+            const manifestPage = page.split('/');
+
+            if (manifestPage.length !== requestedPage.length) {
+                return false;
+            }
+
+            return manifestPage.every(
+                (manifestPathPiece, index) => {
+                    const requestedPathPiece = requestedPage[index];
+
+                    return (
+                        manifestPathPiece === requestedPathPiece || /^\[\w+\]$/.test(manifestPathPiece)
+                    );
+                }
+            );
+        }
+    );
+};
+
+export default getRequestedPageFromURL;


### PR DESCRIPTION
This fixes an issue where doing a first-time offline fetch on routes other than homepage would not work.
This was fixed by pre-caching all routes and implementing a custom offline document resolver which supports dynamic & static routes.