### PR TITLE
Fix pages taking up only half screen on mobile

### DIFF
--- a/src/routes/page/Page.module.scss
+++ b/src/routes/page/Page.module.scss
@@ -6,6 +6,10 @@
         display: grid;
         grid-template-columns: 1fr minmax(var(--sidebar-width), 0);
         grid-column-gap: 2rem;
+
+        @include media.mobile {
+            grid-template-columns: auto;
+        }
     }
 
     &Landing {
@@ -17,10 +21,6 @@
             padding: var(--content-padding);
             margin: 0 auto;
             max-width: var(--content-max-width);
-
-            @include media.mobile {
-                grid-template-columns: auto;
-            }
         }
     }
 


### PR DESCRIPTION
- Fixed pages (other than Home) taking up only half horizontal width on mobile.