### PR TITLE
Fixed banner size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-<div style="width: 100%; text-align: center;">
+<p align="center">
     <img
-      width="100%"
-      style="max-width: 600px;"
+      width="600px"
       alt="PWA Boilerplate"
       src="https://github.com/Tomburgs/pwa-boilerplate/raw/master/docs/pwa-boilerplate.png"
     />


### PR DESCRIPTION
Fixed banner size so that GitHub readme would display it as `max-width: 600px;`