### PR TITLE
Disable pinch-to-zoom

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,7 +23,7 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
     return (
         <>
             <Head>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1, user-scalable=0, viewport-fit=cover" />
                 <meta name="apple-mobile-web-app-capable" content="yes" />
                 <meta name="apple-mobile-web-app-status-bar-style" content={ statusBarStyle } />
                 <link rel="apple-touch-startup-image" sizes="512x512" href="/logo512.png" />


### PR DESCRIPTION
### What changes does this introduce?

Disable pinch-to-zoom
I think it is a better user experience to disable pinch-to-zoom because it is rarely used in app environment.


### Explain your solution

maximum-scale=1.0 : limit maximum zoom scale to 1.0
minimum-scale=1.0 : limit minimum zoom scale to 1.0
user-scalable=0 : prevent a user from zooming to pinch-to-zoom or double touch

### Related issues

Let us know if this is related to any issues or discussions.
