### PR TITLE
feat: add theme toggler settings

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,12 +3,20 @@
   "ignoreFiles": ["!**/*.scss"],
   "rules": {
     "indentation": [2],
-    "max-nesting-depth": 3,
+    "max-nesting-depth": 4,
     "selector-no-qualifying-type": null,
     "selector-max-id": null,
     "scss/at-mixin-pattern": null,
     "scss/at-function-pattern": null,
     "selector-class-pattern": null,
-    "length-zero-no-unit": null
+    "length-zero-no-unit": null,
+    "order/properties-alphabetical-order": null,
+    "order/order": [
+      "custom-properties",
+      "dollar-variables",
+      "declarations",
+      "at-rules",
+      "rules"
+    ]
   }
 }

--- a/src/components/a2hs/A2HS.module.scss
+++ b/src/components/a2hs/A2HS.module.scss
@@ -1,9 +1,9 @@
 @use 'styles/variables/button';
 
 .button {
-  @include button.default;
     
   margin: 1rem 0;
+  @include button.default;
 }
 
 .A2HS {

--- a/src/components/header/themeToggler/ThemeToggler.component.tsx
+++ b/src/components/header/themeToggler/ThemeToggler.component.tsx
@@ -1,51 +1,105 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { SyntheticEvent, useCallback, useMemo, useRef, useState } from 'react';
 import Head from 'next/head';
 import { useTheme } from 'hooks/theme';
 import Icon from 'components/icon';
+import Switch from 'components/switch';
 import { theme } from 'config';
+import {injectClassNames} from 'utils/css';
+import {useOutsideClick} from 'hooks/events';
 import styles from './ThemeToggler.module.scss';
 
 const {
   themeToggler,
   themeTogglerIcon,
+  themeTogglerSettingsOpen,
+  themeTogglerSettings,
   statusBarHighlight 
 } = styles;
 
+const DARK_MODE_SETTING = 'dark-mode-enabled';
+const SYSTEM_THEME_SETTING = 'system-theme-enabled';
+
 export default function ThemeToggler(): JSX.Element {
-  const [isDarkModeEnabled, setIsDarkModeEnabled] = useTheme();
+  const { userTheme, systemTheme } = useTheme();
+  const [isDarkModeEnabled, setIsDarkModeEnabled] = userTheme;
+  const [isSystemThemeUsed, setIsSystemThemeUsed] = systemTheme;
+  const [isSettingMenuOpen, setIsSettingMenuOpen] = useState(false);
+  const settingMenuRef = useRef<HTMLUListElement | null>(null);
   const themeColor = isDarkModeEnabled ? theme.dark : theme.light;
 
-  const toggleTheme = useCallback(
-    () => setIsDarkModeEnabled(!isDarkModeEnabled),
-    [isDarkModeEnabled]
+  const onToggleTheme = useCallback((): void => {
+    setIsSystemThemeUsed(false);
+    setIsDarkModeEnabled(
+      isDarkModeEnabled => !isDarkModeEnabled
+    );
+  }, [setIsSystemThemeUsed, setIsDarkModeEnabled]);
+  const onToggleSystemTheme = useCallback((): void => {
+    setIsSystemThemeUsed(isSystemThemeUsed => !isSystemThemeUsed);
+  }, [setIsSystemThemeUsed]);
+  const onToggleSettings = useCallback((event: SyntheticEvent<HTMLButtonElement>): void => {
+    event.preventDefault();
+
+    setIsSettingMenuOpen(
+      isSettingMenuOpen => !isSettingMenuOpen
+    );
+  }, [setIsSettingMenuOpen]);
+
+  const themeTogglerWrapper = injectClassNames(
+    styles.themeTogglerWrapper,
+    [themeTogglerSettingsOpen, isSettingMenuOpen]
   );
 
-  return useMemo(
-    () => (
-      <>
-        <Head>
-          <meta name="theme-color" content={ themeColor } />
-        </Head>
-        { /*
-                   * We're using black-translucent status bar setting on IOS,
-                   * which means that status bar has white text & tranparent background.
-                   * In light mode this causes the text to be invisible, so we create
-                   * a <figure> to put a different-colored bar behind env(safe-area-inset-top),
-                   * so that the text can be seen.
-                   *
-                   * Currently this is the only way to do this, as IOS will not listen for status bar
-                   * meta tag changes, and other settings create a significantly worse feel.
-                   */ }
-        <figure className={ statusBarHighlight }/>
-        <button
-          aria-label="change theme"
-          className={ themeToggler }
-          onClick={ toggleTheme }
-        >
-          <Icon asset="Moon" className={ themeTogglerIcon } />
-          <Icon asset="Sun" className={ themeTogglerIcon } />
-        </button>
-      </>
-    ), [isDarkModeEnabled, setIsDarkModeEnabled]
+  useOutsideClick(settingMenuRef, () => {
+    setIsSettingMenuOpen(false);
+  });
+
+  return (
+    <>
+      <Head>
+        <meta name="theme-color" content={ themeColor } />
+      </Head>
+      { /*
+           * We're using black-translucent status bar setting on IOS,
+           * which means that status bar has white text & tranparent background.
+           * In light mode this causes the text to be invisible, so we create
+           * a <figure> to put a different-colored bar behind env(safe-area-inset-top),
+           * so that the text can be seen.
+           *
+           * Currently this is the only way to do this, as IOS will not listen for status bar
+           * meta tag changes, and other settings create a significantly worse feel.
+           */ }
+      <figure className={ statusBarHighlight }/>
+      <div className={ themeTogglerWrapper }>
+        { useMemo(() => (
+          <button
+            aria-label="change theme"
+            className={ themeToggler }
+            onContextMenu={ onToggleSettings }
+            onClick={ onToggleTheme }
+          >
+            <Icon asset="Moon" className={ themeTogglerIcon } />
+            <Icon asset="Sun" className={ themeTogglerIcon } />
+          </button>
+        ), [onToggleSettings, onToggleTheme]) }
+        <ul className={ themeTogglerSettings } ref={ settingMenuRef }>
+          <li>
+            <Switch
+              id={ DARK_MODE_SETTING }
+              checked={ !isSystemThemeUsed && isDarkModeEnabled }
+              onClick={ onToggleTheme }
+              disabled={ isSystemThemeUsed }
+            />
+            <label htmlFor={ DARK_MODE_SETTING }>Use Dark Mode</label>
+          </li>
+          <li>
+            <Switch
+              id={ SYSTEM_THEME_SETTING }
+              checked={ isSystemThemeUsed }
+              onClick={ onToggleSystemTheme }
+            />
+            <label htmlFor={ SYSTEM_THEME_SETTING }>Use System Theme</label></li>
+        </ul>
+      </div>
+    </>
   );
 }

--- a/src/components/header/themeToggler/ThemeToggler.module.scss
+++ b/src/components/header/themeToggler/ThemeToggler.module.scss
@@ -1,4 +1,5 @@
 @use 'styles/variables/theme';
+@use 'styles/variables/media';
 
 @keyframes moveIn {
   from { transform: translateX(-200%); }
@@ -24,14 +25,20 @@
   }
 }
 
+@mixin themeTogglerSettingsOpen {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
 .themeToggler {
+  $theme-toggler: &;
+
   align-items: center;
   border: var(--border);
   border-radius: 50%;
   display: flex;
   height: 50px;
   justify-content: center;
-  margin: 0 0 0 1rem;
   overflow: hidden;
   padding: 6px;
   position: relative;
@@ -42,6 +49,61 @@
 
     fill: transparent;
     position: absolute;
+  }
+
+  &Settings {
+    display: flex;
+    flex-flow: column;
+    position: absolute;
+    padding: var(--content-padding);
+    top: calc(var(--header-navigation-height) - 5px);
+    left: 50%;
+    opacity: 0;
+    transform: translateX(-50%) scale(0);
+    box-sizing: border-box;
+    background-color: var(--primary-block-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow);
+    transition-duration: 200ms;
+    transition-property: transform, opacity;
+    transition-timing-function: ease-in-out;
+
+    > li {
+      display: flex;
+      flex-flow: row;
+      align-items: center;
+      gap: 10px;
+
+      &:not(:first-child) {
+        margin: var(--content-padding) 0 0;
+      }
+    }
+
+    label {
+      white-space: nowrap;
+    }
+  }
+
+  &SettingsOpen {
+    #{$theme-toggler}Settings {
+      @include themeTogglerSettingsOpen;
+    }
+  }
+
+  &Wrapper {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    margin: 0 0 0 1rem;
+    position: relative;
+
+    &:hover {
+      #{$theme-toggler}Settings {
+        @include media.before-desktop {
+          @include themeTogglerSettingsOpen;
+        }
+      }
+    }
   }
 
   > * {

--- a/src/components/icon/Icon.module.scss
+++ b/src/components/icon/Icon.module.scss
@@ -7,7 +7,7 @@
 }
 
 .loader {
+  border-radius: 50%;
 
   @include placeholder;
-  border-radius: 50%;
 }

--- a/src/components/placeholder/Placeholder.module.scss
+++ b/src/components/placeholder/Placeholder.module.scss
@@ -5,9 +5,9 @@
   pointer-events: none;
 
   &::after {
+    color: transparent;
 
     @include placeholder;
-    color: transparent;
   }
 }
 

--- a/src/components/switch/Switch.component.tsx
+++ b/src/components/switch/Switch.component.tsx
@@ -1,0 +1,21 @@
+import React, { InputHTMLAttributes } from 'react';
+import styles from './Switch.module.scss';
+
+type SwitchProps = {
+  id: string,
+  className?: string
+} & InputHTMLAttributes<HTMLInputElement>;
+
+export default function Switch({ id, className, ...inputProps }: SwitchProps): JSX.Element {
+  return (
+    <div className={ className }>
+      <input
+        { ...inputProps }
+        id={ id }
+        type="checkbox"
+        className={ styles.input }
+      />
+      <label htmlFor={ id } className={ styles.switch } />
+    </div>
+  );
+}

--- a/src/components/switch/Switch.module.scss
+++ b/src/components/switch/Switch.module.scss
@@ -1,0 +1,52 @@
+@use 'styles/variables/theme';
+
+$input: null;
+
+.input {
+  $input: & !global;
+
+  position: absolute;
+  max-height: 0;
+  opacity: 0;
+}
+
+.switch {
+  --checked-color: #3ce155;
+  --indicator-color: #69696e;
+
+  display: flex;
+  position: relative;
+  background-color: var(--secondary-block-color);
+  cursor: pointer;
+  border: var(--border);
+  width: 30px;
+  height: 15px;
+  border-radius: 8px;
+
+  @include theme.dark-mode {
+    --indicator-color: #fff;
+  }
+
+  #{$input}:checked + & {
+    background-color: var(--checked-color);
+  }
+
+  #{$input}:disabled + & {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background-color: var(--indicator-color);
+    transition: 100ms transform ease-in-out;
+
+    #{$input}:checked + & {
+      transform: translateX(15px);
+    }
+  }
+}

--- a/src/components/switch/index.ts
+++ b/src/components/switch/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Switch.component';

--- a/src/hooks/events/index.ts
+++ b/src/hooks/events/index.ts
@@ -1,0 +1,1 @@
+export { useOutsideClick } from './useOutsideClick';

--- a/src/hooks/events/useOutsideClick.ts
+++ b/src/hooks/events/useOutsideClick.ts
@@ -1,0 +1,21 @@
+import { RefObject, useEffect } from 'react';
+
+export const useOutsideClick = (
+  ref: RefObject<HTMLElement | null>,
+  callback: () => void
+): void => {
+  useEffect(() => {
+    const handler = (event: MouseEvent): void => {
+      // Check if the mouse click was within the element's ref.
+      if (!ref?.current?.contains(event?.target as Node)) {
+        callback();
+      }
+    };
+
+    window.addEventListener('mousedown', handler);
+
+    return (): void => {
+      window.removeEventListener('mousedown', handler);
+    };
+  }, [ref, callback]);
+};

--- a/src/hooks/theme/useTheme.ts
+++ b/src/hooks/theme/useTheme.ts
@@ -2,7 +2,11 @@ import { useContext } from 'react';
 import { ThemeContext, ThemeValue } from 'contexts/theme';
 
 const useTheme = (): ThemeValue => {
-  const theme = useContext(ThemeContext) as ThemeValue;
+  const theme = useContext(ThemeContext);
+
+  if (!theme) {
+    throw new Error('Missing ThemeContext');
+  }
 
   return theme;
 };

--- a/src/routes/page/Page.module.scss
+++ b/src/routes/page/Page.module.scss
@@ -42,9 +42,9 @@
 }
 
 .placeholder {
-  @include animations.placeholder;
   margin: 0 0 15px;
   padding-bottom: 20%;
+  @include animations.placeholder;
 
   &:nth-child(n + 2) {
     padding-bottom: 40%;

--- a/src/routes/profile/Profile.module.scss
+++ b/src/routes/profile/Profile.module.scss
@@ -58,10 +58,10 @@
 
 .followers {
   &Placeholder {
-    @include placeholder;
 
     color: transparent;
     margin: 0 5px 0 0;
+    @include placeholder;
 
     &::before { content: '42'; }
   }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -79,14 +79,14 @@ html {
 }
 
 body {
-
-  @include font-family('Raleway', sans-serif);
   background-color: var(--primary-block-color);
   color: var(--primary-text-color);
   font-size: 12px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
+
+  @include font-family('Raleway', sans-serif);
 }
 
 #__next {

--- a/src/styles/variables/button.scss
+++ b/src/styles/variables/button.scss
@@ -15,8 +15,8 @@
 }
 
 @mixin default {
-  @include _base;
   background-color: var(--button-background);
+  @include _base;
 
   &:hover {
     background-color: var(--button-hover);


### PR DESCRIPTION
### What changes does this introduce?

Adds settings dialog to theme toggler, so that it'd be possible to switch back to system values.

To open this dialog you right-click on the theme toggler on desktop, or hover over it on mobile.

https://user-images.githubusercontent.com/23725326/123518242-4fb2d500-d6a5-11eb-9275-5430b08a4d33.mov


