### PR TITLE
fix(Image): flaky loading complete state

### DIFF
--- a/src/routes/page/landing/Landing.module.scss
+++ b/src/routes/page/landing/Landing.module.scss
@@ -50,10 +50,6 @@
     text-align: center;
     padding: var(--content-padding) 0;
 
-    @include media.before-desktop {
-      grid-row: 3;
-    }
-
     a {
       --button-text-color: #f2f2f7;
       --button-font-weight: 600;


### PR DESCRIPTION
### What changes does this introduce?

Fixes flaky image loading state that was caused by ref not always being immediately present in some cases.

### Explain your solution

Use ref callback instead of an object to have a better handle on when image loads / what the DOM state is.